### PR TITLE
Неправильно обрабатываются адреса /?query

### DIFF
--- a/view/View.php
+++ b/view/View.php
@@ -76,7 +76,7 @@ class View extends Simpla
 			// Текущая страница (если есть)
 			$subdir = substr(dirname(dirname(__FILE__)), strlen($_SERVER['DOCUMENT_ROOT']));
 			$page_url = trim(substr($_SERVER['REQUEST_URI'], strlen($subdir)),"/");
-			if(strpos($page_url, '?') > 0)
+			if(strpos($page_url, '?') !== false)
 				$page_url = substr($page_url, 0, strpos($page_url, '?'));
 			$this->page = $this->pages->get_page((string)$page_url);
 			$this->design->assign('page', $this->page);		


### PR DESCRIPTION
Например, [здесь](http://demo.simplacms.ru/?bla) видно, что метатеги и заголовок главной страницы потерялись из-за того что `strpos('?bla', '?') = 0`, поэтому query string не обрезается и движок ищет в базе страницу с урлом `?bla`, естественно, не находит и привет "великолепному интернет-магазину". Сеошники за такое уши оторвут.
