### PR TITLE
фикс массива $product->images на странице товара, когда нет картинок

### DIFF
--- a/view/ProductView.php
+++ b/view/ProductView.php
@@ -30,7 +30,7 @@ class ProductView extends View
 			return false;
 		
 		$product->images = $this->products->get_images(array('product_id'=>$product->id));
-		$product->image = &$product->images[0];
+		$product->image = reset($product->images);
 
 		$variants = array();
 		foreach($this->variants->get_variants(array('product_id'=>$product->id, 'in_stock'=>true)) as $v)


### PR DESCRIPTION
Суть проблемы:
$this->products->get_images(array('product_id'=>$product->id)) возвращает пустой массив, но при обращении &$product->images[0] - создается пустой элемент со значением null.
После строки
$product->image = &$product->images[0]
там уже array( 0 => NULL)

такое поведение воспроизводится как минимум, в php 5.4 
