### PR TITLE
баг с лимитом по умолчанию

### DIFF
--- a/simpla/OrderAdmin.php
+++ b/simpla/OrderAdmin.php
@@ -148,7 +148,7 @@ class OrderAdmin extends Simpla
 			}
 			
 			$products = array();
-			foreach($this->products->get_products(array('id'=>$products_ids)) as $p)
+			foreach($this->products->get_products(array('id'=>$products_ids, 'limit'=>count($products_ids))) as $p)
 				$products[$p->id] = $p;
 	
 			$images = $this->products->get_images(array('product_id'=>$products_ids));		


### PR DESCRIPTION
Срабатывает лимит по умолчанию в 100 записей, тем самым не позволяет показать больше 100 товаров в заказе
