### PR TITLE
фикс при дубле товара

### DIFF
--- a/api/Products.php
+++ b/api/Products.php
@@ -349,6 +349,7 @@ class Products extends Simpla
     	$product = $this->get_product($id);
     	$product->id = null;
     	$product->created = null;
+    	$product->external_id = '';
 
 		// Сдвигаем товары вперед и вставляем копию на соседнюю позицию
     	$this->db->query('UPDATE __products SET position=position+1 WHERE position>?', $product->position);
@@ -377,6 +378,7 @@ class Products extends Simpla
     		if($variant->infinity)
     			$variant->stock = null;
     		unset($variant->infinity);
+    		$variant->external_id = '';
     		$this->variants->add_variant($variant);
     	}
     	


### PR DESCRIPTION
Если используем 1С, то колонку external_id в товаре и варианте надо очистить, что бы не было проблем при синхронизации
